### PR TITLE
Run Automated Backup with caffeinate

### DIFF
--- a/actions/launchdTemplate.xml
+++ b/actions/launchdTemplate.xml
@@ -6,6 +6,8 @@
         <string>io.halprin.backup</string>
         <key>ProgramArguments</key>
         <array>
+            <string>/usr/bin/caffeinate</string>
+            <string>-i</string>
             <string>{{.Script}}</string>
             <string>backup</string>
             <string>{{.ConfigYml}}</string>


### PR DESCRIPTION
Use `caffeinate` to prevent the computer going to sleep when backing up via `launchd`.