### PR TITLE
Identify Program for Install

### DIFF
--- a/actions/install.go
+++ b/actions/install.go
@@ -19,7 +19,7 @@ var launchdId = "io.halprin.backup"
 var launchdConfigPath = filepath.Join(globalDaemons, fmt.Sprintf("%s.plist", launchdId))
 
 type templateFields struct {
-	Script    string
+	Program   string
 	ConfigYml string
 	Interval  string
 }
@@ -68,7 +68,7 @@ func writeOutLaunchdConfig(configFilePath string, month *int, day *int, weekday 
 
 	interval := constructInterval(month, day, weekday, hour, minute)
 	fields := templateFields{
-		Script:    os.Args[0],
+		Program:    os.Args[0],
 		ConfigYml: configFilePath,
 		Interval:  interval,
 	}

--- a/actions/install.go
+++ b/actions/install.go
@@ -66,9 +66,15 @@ func writeOutLaunchdConfig(configFilePath string, month *int, day *int, weekday 
 		return err
 	}
 
+	program, err := os.Executable()
+	if err != nil {
+		program = os.Args[0]
+		log.Printf("Unable to determine program path, so using '%s'", program)
+	}
+
 	interval := constructInterval(month, day, weekday, hour, minute)
 	fields := templateFields{
-		Program:    os.Args[0],
+		Program:   program,
 		ConfigYml: configFilePath,
 		Interval:  interval,
 	}

--- a/actions/launchdTemplate.xml
+++ b/actions/launchdTemplate.xml
@@ -8,7 +8,7 @@
         <array>
             <string>/usr/bin/caffeinate</string>
             <string>-i</string>
-            <string>{{.Script}}</string>
+            <string>{{.Program}}</string>
             <string>backup</string>
             <string>{{.ConfigYml}}</string>
         </array>


### PR DESCRIPTION
Use the executing program's path when installing the `launchd` configuration instead of the the first argument to the program.  Use the first argument only if we cannot determine the path to the executing program.