### PR TITLE
Maintain the Network Connection 

### DIFF
--- a/actions/launchdTemplate.xml
+++ b/actions/launchdTemplate.xml
@@ -7,7 +7,7 @@
         <key>ProgramArguments</key>
         <array>
             <string>/usr/bin/caffeinate</string>
-            <string>-i</string>
+            <string>-sim</string>
             <string>{{.Program}}</string>
             <string>backup</string>
             <string>{{.ConfigYml}}</string>


### PR DESCRIPTION
Backup no longer looses the network connection mid-backup.  The network connection would be lost due to the system sleeping.  This prevents the system from sleeping correctly.